### PR TITLE
Fix concurrency, URL filtering, and automate releases

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,40 +1,58 @@
-# .github/workflows/release.yml
-name: goreleaser
+---
+name: Release
 
 on:
-  pull_request:
   push:
-    # run only against tags
-    tags:
-      - "*"
+    branches:
+      - main
 
-permissions:
-  contents: write
-  packages: write
-  # issues: write
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
-  goreleaser:
+  release:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      security-events: write
+
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
-          go-version: 'stable'
-      # More assembly might be required: Docker logins, GPG, etc.
-      # It all depends on your needs.
-      - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v5
+          go-version-file: go.mod
+          check-latest: true
+
+      - name: Run govulncheck
+        uses: golang/govulncheck-action@v1.0.4
         with:
-          # either 'goreleaser' (default) or 'goreleaser-pro'
+          repo-checkout: false
+
+      - name: Smoke test
+        run: |
+          echo "https://chrisshort.net" > /tmp/urls.txt
+          go run main.go /tmp/urls.txt
+
+      - name: Generate and push version tag
+        run: |
+          VERSION="v0.$(date +'%Y%m%d').${{ github.run_number }}"
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git tag "$VERSION"
+          git push origin "$VERSION"
+
+      - name: Release
+        uses: goreleaser/goreleaser-action@v7
+        with:
           distribution: goreleaser
-          version: latest
+          version: '~> v2'
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          # Your GoReleaser Pro key, if you are using the 'goreleaser-pro' distribution
-          # GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module urlgrabber
 
-go 1.22.1
+go 1.23

--- a/main.go
+++ b/main.go
@@ -44,58 +44,66 @@ func isValidURL(url string) bool {
 	return statusCode >= 200 && statusCode < 400
 }
 
+func checkURLs(candidates []string, urlChan chan<- string, workerPool chan struct{}) {
+	var wg sync.WaitGroup
+	for _, u := range candidates {
+		if !strings.HasPrefix(u, "http://") && !strings.HasPrefix(u, "https://") {
+			continue
+		}
+		wg.Add(1)
+		workerPool <- struct{}{}
+		go func(u string) {
+			defer wg.Done()
+			defer func() { <-workerPool }()
+			if isValidURL(u) {
+				urlChan <- u
+			}
+		}(u)
+	}
+	wg.Wait()
+}
+
 func extractURLs(filePath string, wg *sync.WaitGroup, urlChan chan<- string, workerPool chan struct{}) {
 	defer wg.Done()
 
 	file, err := os.Open(filePath)
 	if err != nil {
-		fmt.Printf("Error opening file %s: %v\n", filePath, err)
+		fmt.Fprintf(os.Stderr, "Error opening file %s: %v\n", filePath, err)
 		return
 	}
 	defer file.Close()
 
 	fileInfo, err := file.Stat()
 	if err != nil {
-		fmt.Printf("Error getting file info for %s: %v\n", filePath, err)
+		fmt.Fprintf(os.Stderr, "Error getting file info for %s: %v\n", filePath, err)
 		return
 	}
 
-	if fileInfo.Size() < int64(maxMemoryFileSize) {
-		workerPool <- struct{}{}
-		// Cache the file in memory if it's small enough
+	if fileInfo.Size() < maxMemoryFileSize {
 		content, err := os.ReadFile(filePath)
 		if err != nil {
-			fmt.Printf("Error reading file %s: %v\n", filePath, err)
+			fmt.Fprintf(os.Stderr, "Error reading file %s: %v\n", filePath, err)
 			return
 		}
-
-		// Process the cached content
-		for _, line := range strings.Split(string(content), ",") {
-			line = strings.TrimSpace(line)
-			if isValidURL(line) {
-				urlChan <- line
+		var candidates []string
+		for _, line := range strings.Split(string(content), "\n") {
+			for _, part := range strings.Split(line, ",") {
+				candidates = append(candidates, strings.TrimSpace(part))
 			}
 		}
-		<-workerPool
+		checkURLs(candidates, urlChan, workerPool)
 	} else {
 		// Process the file line by line for large files
 		scanner := bufio.NewScanner(file)
-
 		for scanner.Scan() {
-			workerPool <- struct{}{}
-			line := scanner.Text()
-			for _, part := range strings.Split(line, ",") {
-				part = strings.TrimSpace(part)
-				if isValidURL(part) {
-					urlChan <- part
-				}
+			var candidates []string
+			for _, part := range strings.Split(scanner.Text(), ",") {
+				candidates = append(candidates, strings.TrimSpace(part))
 			}
-			<-workerPool
+			checkURLs(candidates, urlChan, workerPool)
 		}
-
 		if err := scanner.Err(); err != nil {
-			fmt.Printf("Error reading file %s: %v\n", filePath, err)
-			return
+			fmt.Fprintf(os.Stderr, "Error reading file %s: %v\n", filePath, err)
 		}
 	}
 }
@@ -103,14 +111,14 @@ func extractURLs(filePath string, wg *sync.WaitGroup, urlChan chan<- string, wor
 func main() {
 	flag.Parse()
 
-	if len(os.Args) < 2 {
-		fmt.Println("Usage: go run main.go [--timeout DURATION | -t DURATION] <file1> <file2> ...")
+	if len(flag.Args()) == 0 {
+		fmt.Println("Usage: urlgrabber [--timeout DURATION | -t DURATION] <file1> <file2> ...")
 		flag.PrintDefaults()
 		return
 	}
 
 	urlChan := make(chan string)
-	workerPool := make(chan struct{}, 100) // Adjust the number of concurrent workers as needed
+	workerPool := make(chan struct{}, 100)
 	var wg sync.WaitGroup
 
 	for _, filePath := range flag.Args() {
@@ -128,7 +136,7 @@ func main() {
 		})
 
 		if err != nil {
-			fmt.Printf("Error walking path %s: %v\n", filePath, err)
+			fmt.Fprintf(os.Stderr, "Error walking path %s: %v\n", filePath, err)
 		}
 	}
 


### PR DESCRIPTION
## Summary

- **Concurrency fix**: Extracted `checkURLs()` that spawns a goroutine per URL candidate using the worker pool — HTTP checks now run concurrently instead of serially per file/line
- **URL filtering**: Skip strings that don't start with `http://` or `https://` before hitting the network
- **Arg check**: Use `flag.Args()` instead of `os.Args` so passing only flags correctly shows usage
- **Stderr**: Route all error output to `os.Stderr` consistently
- **go.mod**: Bump minimum Go version to 1.23
- **Release workflow**: Ported from chkcerts — triggers on push to `main`, runs govulncheck, smoke tests the binary, auto-generates a `v0.YYYYMMDD.N` tag, and releases with goreleaser v2

## Test plan

- [ ] Verify `go build ./...` passes locally
- [ ] Merge to main and confirm the release workflow runs, tags, and produces binaries
- [ ] Confirm govulncheck passes
- [ ] Confirm smoke test hits https://chrisshort.net successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)